### PR TITLE
feature(account-center): connect personal info modals with backend APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-accordion": "1.2.2",
-        "@radix-ui/react-alert-dialog": "1.1.4",
+        "@radix-ui/react-alert-dialog": "^1.1.4",
         "@radix-ui/react-aspect-ratio": "1.1.1",
         "@radix-ui/react-avatar": "^1.1.2",
         "@radix-ui/react-checkbox": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@radix-ui/react-accordion": "1.2.2",
-    "@radix-ui/react-alert-dialog": "1.1.4",
+    "@radix-ui/react-alert-dialog": "^1.1.4",
     "@radix-ui/react-aspect-ratio": "1.1.1",
     "@radix-ui/react-avatar": "^1.1.2",
     "@radix-ui/react-checkbox": "1.1.3",

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,157 @@
+"use client"
+
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,39 +1,40 @@
-import * as React from 'react';
-import { Slot } from '@radix-ui/react-slot';
-import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from '@/lib/utils';
+import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
-        default:
-          'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
-          'bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
-          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
         secondary:
-          'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost:
-          'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
-        link: 'text-primary underline-offset-4 hover:underline',
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
-        sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
-        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
-        icon: 'size-9',
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
+        "icon-sm": "size-8",
+        "icon-lg": "size-10",
       },
     },
     defaultVariants: {
-      variant: 'default',
-      size: 'default',
+      variant: "default",
+      size: "default",
     },
   }
-);
+)
 
 function Button({
   className,
@@ -41,11 +42,11 @@ function Button({
   size,
   asChild = false,
   ...props
-}: React.ComponentProps<'button'> &
+}: React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
-    asChild?: boolean;
+    asChild?: boolean
   }) {
-  const Comp = asChild ? Slot : 'button';
+  const Comp = asChild ? Slot : "button"
 
   return (
     <Comp
@@ -53,7 +54,7 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  );
+  )
 }
 
-export { Button, buttonVariants };
+export { Button, buttonVariants }

--- a/src/features/account-center/components/AddressInfoSection.tsx
+++ b/src/features/account-center/components/AddressInfoSection.tsx
@@ -1,4 +1,4 @@
-'use client'
+'use client';
 import { FC, useState } from 'react';
 import { ChevronRight } from 'lucide-react';
 import { TAddressInfoProps } from '../types/personal-info-types';
@@ -69,12 +69,12 @@ const AddressInfoSection: FC<TAddressInfoProps> = ({ home, work }) => {
         </div>
       </div>
       <UpdateHomeAddressModal
-        home={home}
+        location={{ home, work }}
         isUpdateHomeAddressModalOpen={isUpdateHomeAddressModalOpen}
         setIsUpdateHomeAddressModalOpen={setIsUpdateHomeAddressModalOpen}
       />
       <UpdateWorkAddressModal
-        work={work}
+        location={{ home, work }}
         isUpdateWorkAddressModalOpen={isUpdateWorkAddressModalOpen}
         setIsUpdateWorkAddressModalOpen={setIsUpdateWorkAddressModalOpen}
       />

--- a/src/features/account-center/components/ContactInfoSection.tsx
+++ b/src/features/account-center/components/ContactInfoSection.tsx
@@ -3,19 +3,32 @@ import { FC, useState } from 'react';
 import { ChevronRight } from 'lucide-react';
 import UpdatePhoneNumberModal from './UpdatePhoneNumberModal';
 import { TContactInfoProps } from '../types/personal-info-types';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 
 const ContactInfoSection: FC<TContactInfoProps> = ({ email, phone }) => {
   const [isUpdatePhoneModalOpen, setIsUpdatePhoneModalOpen] =
     useState<boolean>(false);
+  const [isEmailWarningOpen, setIsEmailWarningOpen] = useState<boolean>(false);
   const handleOpenUpdatePhoneModal = () => {
     setIsUpdatePhoneModalOpen(true);
+  };
+  const handleEmailClick = () => {
+    setIsEmailWarningOpen(true);
   };
   return (
     <>
       <div className="w-full mt-4 border border-gray-500 lg:px-4 lg:pt-6 lg:pb-4 p-4 rounded-[8px]">
         <h5 className="font-medium text-[16px]">Contact Info</h5>
         <div className="mt-2">
-          <div className="relative">
+          <div onClick={handleEmailClick} className="relative">
             <div className="flex transition-all duration-300 lg:cursor-pointer lg:hover:bg-gray-50/5 lg:p-2 lg:border-b lg:border-gray-400 items-center justify-between w-full">
               <div className="flex flex-col min-[620px]:w-[60%] min-[620px]:flex-row min-[620px]:justify-between min-[620px]:items-center">
                 <h6 className="text-xs font-medium min-[620px]:w-[50%]">
@@ -59,6 +72,24 @@ const ContactInfoSection: FC<TContactInfoProps> = ({ email, phone }) => {
           </div>
         </div>
       </div>
+      <AlertDialog
+        open={isEmailWarningOpen}
+        onOpenChange={setIsEmailWarningOpen}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Email Cannot Be Changed</AlertDialogTitle>
+            <AlertDialogDescription>
+              Your email address cannot be changed as it is linked to your
+              account. If you need to update your email, please contact support
+              for assistance.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogAction>Got it</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
       <UpdatePhoneNumberModal
         isUpdatePhoneModalOpen={isUpdatePhoneModalOpen}
         setIsUpdatePhoneModalOpen={setIsUpdatePhoneModalOpen}

--- a/src/features/account-center/components/PersonalInfoSectionHolder.tsx
+++ b/src/features/account-center/components/PersonalInfoSectionHolder.tsx
@@ -34,7 +34,7 @@ const PersonalInfoSectionHolder: FC = () => {
             name={data.name}
           />
           <ContactInfo email={data.email} phone={data.phone} />
-          <AddressInfo home={data.location.home} work={data.location.home} />
+          <AddressInfo home={data.location.home} work={data.location.work} />
         </Suspense>
       )}
     </ErrorBoundary>

--- a/src/features/account-center/components/PersonalInfoSectionHolder.tsx
+++ b/src/features/account-center/components/PersonalInfoSectionHolder.tsx
@@ -21,7 +21,6 @@ const PersonalInfoSectionHolder: FC = () => {
     queryFn: async () => await GetFullProfileService(),
     queryKey: ['personal_info'],
   });
-  console.log(data);
   return (
     <ErrorBoundary errorComponent={AccountCenterErrorBoundary}>
       {isPending ? (

--- a/src/features/account-center/components/UpdateDateOfBirthModal.tsx
+++ b/src/features/account-center/components/UpdateDateOfBirthModal.tsx
@@ -12,13 +12,49 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { FC, useEffect, useState } from 'react';
-import { TUpdateDateOfBirthModalProps } from '../types/personal-info-types';
+import {
+  TProfileUpdatePayload,
+  TUpdateDateOfBirthModalProps,
+} from '../types/personal-info-types';
+import { UpdateProfileField } from '../services/personal-info-services';
+import { toast } from 'sonner';
+import { AxiosResponse } from 'axios';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
 const UpdateDateOfBirthModal: FC<TUpdateDateOfBirthModalProps> = ({
   isUpdateDateOfBirthModalOpen,
   dateOfBirth,
   setIsUpdateDateOfBirthModalOpen,
 }) => {
+  const queryClient = useQueryClient();
   const [userDob, setUserDob] = useState<string>('');
+  const { isPending, mutate } = useMutation({
+    mutationFn: async (payload: TProfileUpdatePayload) =>
+      await UpdateProfileField(payload),
+    onSuccess: (data) => {
+      queryClient.setQueryData(['personal_info'], (oldData: AxiosResponse) => {
+        if (!oldData) return oldData;
+        return {
+          ...oldData,
+          dateOfBirth: data.dateOfBirth,
+        };
+      });
+      toast.success('Date Of Birth Changed', { closeButton: false });
+      setIsUpdateDateOfBirthModalOpen(false);
+    },
+    onError: (error) => {
+      console.log(error.message);
+      toast.error('Date Of Birth Change Failed,Try Again!', {
+        closeButton: false,
+      });
+    },
+  });
+  const isFieldChange = dateOfBirth === userDob;
+  const handleSave = () => {
+    if (!isFieldChange) {
+      mutate({ dateOfBirth: userDob });
+    }
+  };
   useEffect(() => {
     setUserDob(dateOfBirth ?? '');
   }, [dateOfBirth]);
@@ -48,7 +84,13 @@ const UpdateDateOfBirthModal: FC<TUpdateDateOfBirthModalProps> = ({
           <DialogClose asChild>
             <Button variant="outline">Cancel</Button>
           </DialogClose>
-          <Button type="submit">Save changes</Button>
+          <Button
+            onClick={handleSave}
+            disabled={isFieldChange || isPending}
+            type="submit"
+          >
+            {isPending ? 'Processing...' : 'Save changes'}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/features/account-center/components/UpdateHomeAddressModal.tsx
+++ b/src/features/account-center/components/UpdateHomeAddressModal.tsx
@@ -12,17 +12,53 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { FC, useEffect, useState } from 'react';
-import { TUpdateHomeAddressModalProps } from '../types/personal-info-types';
+import {
+  TUpdateHomeAddressModalProps,
+  TProfileUpdatePayload,
+} from '../types/personal-info-types';
+import { AxiosResponse } from 'axios';
+import { toast } from 'sonner';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { UpdateProfileField } from '../services/personal-info-services';
+
 const UpdateHomeAddressModal: FC<TUpdateHomeAddressModalProps> = ({
-  home,
+  location,
   isUpdateHomeAddressModalOpen,
   setIsUpdateHomeAddressModalOpen,
 }) => {
+  const queryClient = useQueryClient();
   const [userHomeAddress, setUserHomeAddress] = useState<string>('');
-
+  const { isPending, mutate } = useMutation({
+    mutationFn: async (payload: TProfileUpdatePayload) =>
+      await UpdateProfileField(payload),
+    onSuccess: (data) => {
+      queryClient.setQueryData(['personal_info'], (oldData: AxiosResponse) => {
+        if (!oldData) return oldData;
+        return {
+          ...oldData,
+          location: {
+            home: data.location.home,
+            work: data.location.work,
+          },
+        };
+      });
+      toast.success('Home Address Changed', { closeButton: false });
+      setIsUpdateHomeAddressModalOpen(false);
+    },
+    onError: (error) => {
+      console.log(error.message);
+      toast.error('Home Address  Failed,Try Again!', { closeButton: false });
+    },
+  });
+  const isFieldChange = location.home === userHomeAddress;
+  const handleSave = () => {
+    if (!isFieldChange) {
+      mutate({ location: { ...location, home: userHomeAddress } });
+    }
+  };
   useEffect(() => {
-    setUserHomeAddress(home ?? '');
-  }, [home]);
+    setUserHomeAddress(location.home ?? '');
+  }, [location]);
   return (
     <Dialog
       open={isUpdateHomeAddressModalOpen}
@@ -52,7 +88,13 @@ const UpdateHomeAddressModal: FC<TUpdateHomeAddressModalProps> = ({
           <DialogClose asChild>
             <Button variant="outline">Cancel</Button>
           </DialogClose>
-          <Button type="submit">Save changes</Button>
+          <Button
+            onClick={handleSave}
+            disabled={isFieldChange || isPending}
+            type="submit"
+          >
+            {isPending ? 'Processing...' : 'Save changes'}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/features/account-center/components/UpdateNameModal.tsx
+++ b/src/features/account-center/components/UpdateNameModal.tsx
@@ -12,14 +12,46 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { FC, useEffect, useState } from 'react';
-import { TUpdateNameModalProps } from '../types/personal-info-types';
+import {
+  TProfileUpdatePayload,
+  TUpdateNameModalProps,
+} from '../types/personal-info-types';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { UpdateProfileField } from '../services/personal-info-services';
+import { toast } from 'sonner';
+import { AxiosResponse } from 'axios';
 const UpdateNameModal: FC<TUpdateNameModalProps> = ({
   isUpdateNameModalOpen,
   name,
   setIsUpdateNameModalOpen,
 }) => {
+  const queryClient = useQueryClient();
   const [userName, setUserName] = useState<string>('');
-
+  const { isPending, mutate } = useMutation({
+    mutationFn: async (payload: TProfileUpdatePayload) =>
+      await UpdateProfileField(payload),
+    onSuccess: (data) => {
+      queryClient.setQueryData(['personal_info'], (oldData: AxiosResponse) => {
+        if (!oldData) return oldData;
+        return {
+          ...oldData,
+          name: data.name,
+        };
+      });
+      toast.success('Name Changed', { closeButton: false });
+      setIsUpdateNameModalOpen(false);
+    },
+    onError: (error) => {
+      console.log(error.message);
+      toast.error('Name Change Failed,Try Again!', { closeButton: false });
+    },
+  });
+  const isFieldChange = name === userName;
+  const handleSave = () => {
+    if (!isFieldChange) {
+      mutate({ name: userName });
+    }
+  };
   useEffect(() => {
     setUserName(name ?? '');
   }, [name]);
@@ -51,7 +83,13 @@ const UpdateNameModal: FC<TUpdateNameModalProps> = ({
           <DialogClose asChild>
             <Button variant="outline">Cancel</Button>
           </DialogClose>
-          <Button type="submit">Save changes</Button>
+          <Button
+            onClick={handleSave}
+            disabled={isFieldChange || isPending}
+            type="submit"
+          >
+            {isPending ? 'Processing...' : 'Save changes'}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/features/account-center/components/UpdateProfileAvatarModal.tsx
+++ b/src/features/account-center/components/UpdateProfileAvatarModal.tsx
@@ -1,18 +1,164 @@
 'use client';
-import { Dialog } from '@/components/ui/dialog';
-import { FC } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { ChangeEvent, FC, useRef } from 'react';
 import { TUpdateProfileAvatarModalProps } from '../types/personal-info-types';
+import {
+  UpdateProfileAvatar,
+  DeleteProfileAvatar,
+} from '../services/personal-info-services';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Edit, Loader2, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { AxiosResponse } from 'axios';
 
 const UpdateProfileAvatarModal: FC<TUpdateProfileAvatarModalProps> = ({
+  name,
   avatar,
   isUpdateProfileAvatarModalOpen,
   setIsUpdateProfileAvatarModalOpen,
 }) => {
+  const queryClient = useQueryClient();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const { isPending: isChanging, mutate: change } = useMutation({
+    mutationFn: async (payload: FormData) => await UpdateProfileAvatar(payload),
+    onSuccess: (data) => {
+      queryClient.setQueryData(['personal_info'], (oldData: AxiosResponse) => {
+        if (!oldData) return oldData;
+        return {
+          ...oldData,
+          avatar: data,
+        };
+      });
+      setIsUpdateProfileAvatarModalOpen(false);
+      toast.success('Profile Picture Changed', { closeButton: false });
+    },
+    onError: (error) => {
+      console.error('Profile picture change failed:', error);
+      toast.error('Profile picture change failed,Try Again', {
+        closeButton: false,
+      });
+    },
+  });
+  const { isPending: isRemoving, mutate: remove } = useMutation({
+    mutationFn: async (payload: string) => await DeleteProfileAvatar(payload),
+    onSuccess: (data) => {
+      queryClient.setQueryData(['personal_info'], (oldData: AxiosResponse) => {
+        if (!oldData) return oldData;
+        return {
+          ...oldData,
+          avatar: {
+            url: null,
+            publicId: null,
+          },
+        };
+      });
+      setIsUpdateProfileAvatarModalOpen(false);
+      toast.success('Profile Picture Removed', { closeButton: false });
+    },
+    onError: (error) => {
+      console.error('Profile picture upload failed:', error);
+      toast.error('Profile picture upload failed,Try Again', {
+        closeButton: false,
+      });
+    },
+  });
+  const isLoading = isChanging || isRemoving;
+  const hasAvatar = Boolean(avatar?.url);
+  const avatarUrl =
+    avatar?.url || `https://api.dicebear.com/7.x/initials/svg?seed=${name}`;
+
+  const handleEditClick = () => {
+    fileInputRef.current?.click();
+  };
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      const payload = new FormData();
+      payload.append('publicId', avatar.publicId as string);
+      payload.append('avatar', file);
+      change(payload);
+    }
+  };
+  const handleRemoveClick = () => {
+    if (avatar.publicId) {
+      remove(avatar.publicId);
+    }
+  };
   return (
     <Dialog
       onOpenChange={setIsUpdateProfileAvatarModalOpen}
       open={isUpdateProfileAvatarModalOpen}
-    ></Dialog>
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Profile Picture</DialogTitle>
+          <DialogDescription>
+            Update or remove your profile picture
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col items-center gap-6 py-4">
+          <div className="relative">
+            <Avatar className="size-32 border-2 border-border">
+              <AvatarImage src={avatarUrl || '/placeholder.svg'} alt={name} />
+              <AvatarFallback className="text-2xl">
+                {name.slice(0, 2).toUpperCase()}
+              </AvatarFallback>
+            </Avatar>
+            {/* Loading Overlay */}
+            {isLoading && (
+              <div className="absolute inset-0 flex items-center justify-center rounded-full bg-background/80 backdrop-blur-sm">
+                <Loader2 className="size-8 animate-spin text-primary" />
+              </div>
+            )}
+          </div>
+          {/* Action Buttons */}
+          <div className="flex w-full gap-3">
+            <Button
+              onClick={handleEditClick}
+              disabled={isLoading || !hasAvatar}
+              className="flex-1"
+              variant="default"
+            >
+              <Edit className="size-4" />
+              Change
+            </Button>
+
+            <Button
+              onClick={handleRemoveClick}
+              disabled={isLoading || !hasAvatar}
+              variant="destructive"
+              className="flex-1"
+            >
+              <Trash2 className="size-4" />
+              Remove
+            </Button>
+          </div>
+          {/* Helper Text */}
+          <p className="text-center text-xs text-muted-foreground">
+            Recommended: Square image, at least 400x400px
+            <br />
+            Max file size: 5MB
+          </p>
+        </div>
+        {/* Hidden File Input */}
+        <input
+          type="file"
+          accept="image/*"
+          ref={fileInputRef}
+          className="hidden"
+          onChange={handleFileChange}
+          disabled={isLoading}
+        />
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/src/features/account-center/services/personal-info-services.ts
+++ b/src/features/account-center/services/personal-info-services.ts
@@ -1,6 +1,7 @@
 'use client';
 import axiosClient from '@/lib/axios';
 import { AxiosError } from 'axios';
+import { TProfileUpdatePayload } from '../types/personal-info-types';
 
 export const GetFullProfileService = async () => {
   try {
@@ -47,5 +48,15 @@ export const DeleteProfileAvatar = async (payload: string) => {
   } catch (error) {
     if (error instanceof AxiosError) throw error;
     throw new Error('Unknown Error Occurred In Delete Profile Avatar Service');
+  }
+};
+
+export const UpdateProfileField = async (payload: TProfileUpdatePayload) => {
+  try {
+    const response = await axiosClient.patch('/me', payload);
+    return response.data.data;
+  } catch (error) {
+    if (error instanceof AxiosError) throw error;
+    throw new Error('Unknown Error Occurred In Update Profile Field Service');
   }
 };

--- a/src/features/account-center/services/personal-info-services.ts
+++ b/src/features/account-center/services/personal-info-services.ts
@@ -1,4 +1,4 @@
-'use client'
+'use client';
 import axiosClient from '@/lib/axios';
 import { AxiosError } from 'axios';
 
@@ -12,12 +12,40 @@ export const GetFullProfileService = async () => {
   }
 };
 
-export const UploadProfileAvatar = async () => {
+export const UploadProfileAvatar = async (payload: FormData) => {
   try {
-    const response = await axiosClient.get('/me');
+    const response = await axiosClient.put('/me/avatar', payload, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
     return response?.data?.data;
   } catch (error) {
     if (error instanceof AxiosError) throw error;
-    throw new Error('Unknown Error Occurred In Get Full Profile Service');
+    throw new Error('Unknown Error Occurred In Upload Profile Avatar Service');
+  }
+};
+
+export const UpdateProfileAvatar = async (payload: FormData) => {
+  try {
+    const response = await axiosClient.patch('/me/avatar', payload, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+    return response?.data?.data;
+  } catch (error) {
+    if (error instanceof AxiosError) throw error;
+    throw new Error('Unknown Error Occurred In Update Profile Avatar Service');
+  }
+};
+
+export const DeleteProfileAvatar = async (payload: string) => {
+  try {
+    const response = await axiosClient.delete(`/me/avatar/${payload}`);
+    return response?.data?.data;
+  } catch (error) {
+    if (error instanceof AxiosError) throw error;
+    throw new Error('Unknown Error Occurred In Delete Profile Avatar Service');
   }
 };

--- a/src/features/account-center/types/personal-info-types.ts
+++ b/src/features/account-center/types/personal-info-types.ts
@@ -58,6 +58,7 @@ export type TUpdateWorkAddressModalProps = {
 };
 
 export type TUpdateProfileAvatarModalProps = {
+  name: string;
   avatar: TImage;
   isUpdateProfileAvatarModalOpen: boolean;
   setIsUpdateProfileAvatarModalOpen: Dispatch<SetStateAction<boolean>>;

--- a/src/features/account-center/types/personal-info-types.ts
+++ b/src/features/account-center/types/personal-info-types.ts
@@ -46,13 +46,13 @@ export type TAddressInfoProps = {
 };
 
 export type TUpdateHomeAddressModalProps = {
-  home: string | null;
+  location: TAddressInfoProps;
   isUpdateHomeAddressModalOpen: boolean;
   setIsUpdateHomeAddressModalOpen: Dispatch<SetStateAction<boolean>>;
 };
 
 export type TUpdateWorkAddressModalProps = {
-  work: string | null;
+  location: TAddressInfoProps;
   isUpdateWorkAddressModalOpen: boolean;
   setIsUpdateWorkAddressModalOpen: Dispatch<SetStateAction<boolean>>;
 };

--- a/src/features/account-center/types/personal-info-types.ts
+++ b/src/features/account-center/types/personal-info-types.ts
@@ -63,3 +63,11 @@ export type TUpdateProfileAvatarModalProps = {
   isUpdateProfileAvatarModalOpen: boolean;
   setIsUpdateProfileAvatarModalOpen: Dispatch<SetStateAction<boolean>>;
 };
+
+export type TProfileUpdatePayload = {
+  location?: TAddressInfoProps;
+  dateOfBirth?: string;
+  name?: string;
+  phone?: string;
+  gender?: string;
+};

--- a/src/features/dashboard/components/NavUser.tsx
+++ b/src/features/dashboard/components/NavUser.tsx
@@ -45,6 +45,7 @@ export default function NavUser() {
       <DropdownMenuContent className="mt-2 w-72 mr-4 md:mr-7 ">
         <DropdownMenuItem className="py-3 cursor-pointer hover:!bg-gray-100 hover:!text-primary">
           <Avatar>
+            <AvatarImage src={data?.avatar?.url} alt={data?.name} />
             <AvatarFallback className="bg-primary text-primary-foreground">
               {data?.name.slice(0, 2).toUpperCase()}
             </AvatarFallback>


### PR DESCRIPTION
## Description

This pull request implements full API integration for the Account Center modals and profile management functionality. The changes include:

- API integration for updating **name**, **date of birth**, **gender**, **phone**, and **location** through their respective modals.
- Implementation of **profile picture upload, update, and removal** functionality.

These updates ensure that users can manage all their personal information and profile settings directly from the Account Center UI, providing a seamless and interactive experience.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation update

## Checklist

- [x] I have tested the changes locally
- [ ] I have added/updated necessary documentation
- [x] I have reviewed the code for any errors

## Related Issue

This pull request is not related to any existing issue.

## Additional Notes

- All API endpoints for the modals are fully functional.
- Profile picture functionality handles upload, update, and removal efficiently.
- Further enhancements may include additional validation and error handling for edge cases.
